### PR TITLE
EPS & UHF service update

### DIFF
--- a/CommandDocs.txt
+++ b/CommandDocs.txt
@@ -110,7 +110,7 @@ COMMUNICATION.S_SOFT_RESET:
 COMMUNICATION.S_GET_FULL_STATUS:
 		About: A full status of S-band non-configurable parameters
 		Arguments: [None]
-		return values: {'err': '>b', 'PWRGD': '>u1', 'TXL': '>u1', 'Transmit Ready': '>i4', 'Buffer Count': '>u2', 'Buffer Underrun': '>u2', 'Buffer Overrun': '>u2', 'Output Power': '>f', 'Power Amplifier Temperature': '>f', 'Top Temperature': '>f', 'Bottom Temperature': '>f', 'Battery Current': '>f', 'Battery Voltage': '>f', 'Power Amplifier Current': '>f', 'Power Amplifier Voltage': '>f', 'Firmware Version': '>f'}
+		return values: {'err': '>b', 'PWRGD': '>u1', 'TXL': '>u1', 'Transmit Ready': '>i4', 'Buffer Count': '>u2', 'Buffer Underrun': '>u2', 'Buffer Overrun': '>u2', 'Output Power': '>f', 'Power Amplifier Temperature': '>f', 'Top Temperature': '>f', 'Bottom Temperature': '>f', 'Battery Current': '>f', 'Battery Voltage': '>f', 'Power Amplifier Current': '>f', 'Power Amplifier Voltage': '>f'}
 		port: 10		subport: 10
 
 
@@ -271,7 +271,7 @@ COMMUNICATION.UHF_SECURE:
 COMMUNICATION.UHF_GET_FULL_STAT:
 		About: Returns the full status of all the UHF non-configurable parameters
 		Arguments: [None]
-		return values: {'err': '>b', 'HFXT': '>u1', 'UartBaud': '>u1', 'Reset': '>u1', 'RF Mode': '>u1', 'Echo': '>u1', 'BCN': '>u1', 'PIPE': '>u1', 'Bootloader': '>u1', 'CTS': '>u1', 'SEC': '>u1', 'FRAM': '>u1', 'RFTS': '>u1', 'Frequency': '>u4', 'PIPE timeout': '>u2', 'Beacon period': '>u2', 'Audio trans. period': '>u2', 'Uptime': '>u4', 'Packets out': '>u4', 'Packets in': '>u4', 'Packets in CRC16': '>u4', 'Temperature': '>f', 'Low power status': '>u1', 'Payload Size': '>u2', 'Secure key': '>u4'}
+		return values: {'err': '>b', 'HFXT': '>u1', 'UartBaud': '>u1', 'Reset': '>u1', 'RF Mode': '>u1', 'Echo': '>u1', 'BCN': '>u1', 'PIPE': '>u1', 'Bootloader': '>u1', 'CTS': '>u1', 'SEC': '>u1', 'FRAM': '>u1', 'RFTS': '>u1', 'Frequency': '>u4', 'PIPE timeout': '>u2', 'Beacon period': '>u2', 'Audio trans. period': '>u2', 'Uptime': '>u4', 'Packets out': '>u4', 'Packets in': '>u4', 'Packets in CRC16': '>u4', 'Temperature': '>f'}
 		port: 10		subport: 36
 
 
@@ -330,6 +330,12 @@ COMMUNICATION.UHF_SET_ECHO:
 		return values: {'err': '>b'}
 		port: 10		subport: 44
 
+COMMUNICATION.UHF_GET_SECURE_KEY:
+		About: Gets the key for secure mode
+		Arguments: [None]
+		return values: {'err': '>b', 'Secure Key': '>u4'}
+		port: 10		subport: 45
+
 
 HOUSEKEEPING.PARAMETER_REPORT:
 		About: None
@@ -384,7 +390,7 @@ REBOOT:
 		About: Does a soft reset on EPS (reboot). Be cautious.
 		Arguments: [<u4]
 		return values: {'err': '>b'}
-		port: 4		subport: None
+		port: 4		subport: 128
 
 
 CLI.GENERAL_TELEMETERY:
@@ -464,8 +470,99 @@ CONTROL.SET_HEATER_STATE:
 		port: 14		subport: 7
 
 
-CONTROL.PAUSE_EPS_DEPLOYMENT_ACTION:
-		About: Pauses a certain action group deployment for a set time
-		Arguments: [>B, <u4]
+CONFIGURATION.GET_ACTIVE_CONFIG:
+		About: Gets config values in active mode for a specific type
+		Arguments: [<u2, <u1]
+		return values: {'err': '>b' , 'type': '<u1', 'Value': 'var'}
+		port: 9		subport: 0
+
+
+CONFIGURATION.GET_MAIN_CONFIG:
+		About: Gets config values in main mode for a specific type
+		Arguments: [<u2, <u1]
+		return values: {'err': '>b' , 'type': '<u1', 'Value': 'var'}
+		port: 9		subport: 1
+
+
+CONFIGURATION.GET_FALLBACK_CONFIG:
+		About: Gets config values in fallback mode for a specific type
+		Arguments: [<u2, <u1]
+		return values: {'err': '>b' , 'type': '<u1', 'Value': 'var'}
+		port: 9		subport: 2
+
+
+CONFIGURATION.GET_DEFAULT_CONFIG:
+		About: Gets config values in default mode for a specific type
+		Arguments: [<u2, <u1]
+		return values: {'err': '>b' , 'type': '<u1', 'Value': 'var'}
+		port: 9		subport: 3
+
+
+CONFIGURATION.SET_CONFIG:
+		About: Sets the configuration in the current mode
+		Arguments: [<u2, <u1, var]
 		return values: {'err': '>b'}
-		port: 14		subport: 8		
+		port: 9		subport: 4
+
+
+CONFIGURATION.LOAD_MAIN2ACTIVE:
+		About: Loads main configuration from file into active
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 5
+
+
+CONFIGURATION.LOAD_FALLBACK2ACTIVE:
+		About: Loads fallback configuration from file into active
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 6
+
+
+CONFIGURATION.LOAD_DEFAULT2ACTIVE:
+		About: Loads default configuration from file into active
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 7
+
+
+CONFIGURATION.UNLOCK_CONFIG:
+		About: Unlocks configuration for saving
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 8
+
+
+CONFIGURATION.LOCK_CONFIG:
+		About: Locks configuration for saving
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 9
+
+
+CONFIGURATION.SAVE_ACTIVE2MAIN:
+		About: Saves active configuration to main file
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 10
+
+
+CONFIGURATION.SAVE_ACTIVE2FALLBACK:
+		About: Saves active configuration to fallback file
+		Arguments: [None]
+		return values: {'err': '>b'}
+		port: 9		subport: 11
+
+
+CONFIGURATION.ELEVATE_ACCESS:
+		About: Elevates access role
+		Arguments: [<u1, <u4]
+		return values: {'err': '>b'}
+		port: 9		subport: 12
+
+
+CONFIGURATION.GET_STATUS:
+		About: Gets the status and errors info
+		Arguments: [None]
+		return values: {'err': '>B', 'isInitialized': '<u1', 'isLocked': '<u1', 'isFallbackConfigurationLoaded': '<u1', 'isMainConfigurationLoaded': '<u1', 'wasFallbackRequested': '<u1', 'initSource': '<u1', 'currAccessRole': '<u1', 'totalNumofErrors': '<u1', 'numOfParameterDoesNotExistErrors': '<u1', 'numOfInvalidParameterTypeErrors': '<u1', 'numOfValidationFailErrors': '<u1', 'numOfStorageFailErrors': '<u1', 'numOfNotInitializedErrors': '<u1', 'numOfNotLoadedOnInitErrors': '<u1', 'numOfLockedErrors': '<u1', 'numOfAccessDeniedErrors': '<u1', 'numOfWrongPasswordErrors': '<u1', 'numOfUnknownErrors': '<u1'}
+		port: 9		subport: 13

--- a/src/groundStation/commandParser.py
+++ b/src/groundStation/commandParser.py
@@ -110,7 +110,7 @@ class CommandParser(object):
         returns = subservice['inoutInfo']['returns']
         args = subservice['inoutInfo']['args']
         for retVal in returns:
-            if returns[retVal] is 'var' and dport == 9 and subservice['subPort'] < 4:
+            if returns[retVal] == 'var' and dport == 9 and subservice['subPort'] < 4:
                 #Variable size config return
                 if outputObj['type'] == 0:
                     config_type = np.dtype('<u1')
@@ -120,16 +120,16 @@ class CommandParser(object):
                     config_type = np.dtype('<u2')
                 elif outputObj['type'] == 4:
                     config_type = np.dtype('<u4')
-                elif outputObj['type'] == 14:
-                    config_type = np.dtype('<S16')
+                elif outputObj['type'] == 9:
+                    config_type = np.dtype('<S16') #Empty means all zero or Use <V16
                                         
                 outputObj[retVal] = np.frombuffer( data, dtype = config_type, count=1, offset=idx)[0]
                 return outputObj
                 
             else:
-            outputObj[retVal] = np.frombuffer(
-                data, dtype=returns[retVal], count=1, offset=idx)[0]
-            idx += np.dtype(returns[retVal]).itemsize
+                outputObj[retVal] = np.frombuffer(
+                    data, dtype=returns[retVal], count=1, offset=idx)[0]
+                idx += np.dtype(returns[retVal]).itemsize
 
         return outputObj
 
@@ -163,7 +163,21 @@ class CommandParser(object):
 
         for i in range(0, len(args)):
             if inoutInfo['args'][i]:
-                nparr = np.array([args[i]], dtype=inoutInfo['args'][i])
+                if inoutInfo['args'][i] == 'var' and self._command['dport'] == 9 and outArgs[0] == 4:
+                    #Variable size config return
+                    if outArgs[-1] == 0:
+                        config_type = np.dtype('<u1')
+                    elif outArgs[-1] == 1:
+                        config_type = np.dtype('<i1')
+                    elif outArgs[-1] == 2:
+                        config_type = np.dtype('<u2')
+                    elif outArgs[-1] == 4:
+                        config_type = np.dtype('<u4')
+                    elif outArgs[-1] == 9:
+                        config_type = np.dtype('<S16')                   
+                    nparr = np.array([args[i]], dtype=config_type)
+                else :
+                    nparr = np.array([args[i]], dtype=inoutInfo['args'][i])
                 outArgs.extend(nparr.tobytes())
         self._command['args'] = outArgs
         return True

--- a/src/groundStation/commandParser.py
+++ b/src/groundStation/commandParser.py
@@ -152,7 +152,7 @@ class CommandParser(object):
     def __lexer(self, input):
         tokenList = []
         # If an old command is not parsed, use '([a-zA-Z_-]+|[\(\)]|[0-9_.-]*)' and make an issue
-        tmp = re.split('([-.]+|[0-9.]+|[a-zA-Z0-9_-]+|[\(\)])', input)
+        tmp = re.split('([-.|]+|[0-9.]+|[a-zA-Z0-9_-]+|[\(\)])', input)
         [tokenList.append(x.upper()) for x in tmp if not (
             str(x).strip() == '' or str(x).strip() == ',')]  # to accept ',' as delimiter
         return tokenList

--- a/src/groundStation/commandParser.py
+++ b/src/groundStation/commandParser.py
@@ -112,12 +112,25 @@ class CommandParser(object):
         for retVal in returns:
             if returns[retVal] is 'var' and dport == 9 and subservice['subPort'] < 4:
                 #Variable size config return
-                outputObj[retVal] = np.frombuffer( data, dtype = args[-1], count=1, offset=idx)[0]
+                if outputObj['type'] == 0:
+                    config_type = np.dtype('<u1')
+                elif outputObj['type'] == 1:
+                    config_type = np.dtype('<i1')
+                elif outputObj['type'] == 2:
+                    config_type = np.dtype('<u2')
+                elif outputObj['type'] == 4:
+                    config_type = np.dtype('<u4')
+                elif outputObj['type'] == 14:
+                    config_type = np.dtype('<S16')
+                                        
+                outputObj[retVal] = np.frombuffer( data, dtype = config_type, count=1, offset=idx)[0]
                 return outputObj
-            print(returns[retVal])
+                
+            else:
             outputObj[retVal] = np.frombuffer(
                 data, dtype=returns[retVal], count=1, offset=idx)[0]
             idx += np.dtype(returns[retVal]).itemsize
+
         return outputObj
 
     ''' PRIVATE METHODS '''

--- a/src/groundStation/commandParser.py
+++ b/src/groundStation/commandParser.py
@@ -108,7 +108,13 @@ class CommandParser(object):
 
         print(length)
         returns = subservice['inoutInfo']['returns']
+        args = subservice['inoutInfo']['args']
         for retVal in returns:
+            if returns[retVal] is 'var' and dport == 9 and subservice['subPort'] < 4:
+                #Variable size config return
+                outputObj[retVal] = np.frombuffer( data, dtype = args[-1], count=1, offset=idx)[0]
+                return outputObj
+            print(returns[retVal])
             outputObj[retVal] = np.frombuffer(
                 data, dtype=returns[retVal], count=1, offset=idx)[0]
             idx += np.dtype(returns[retVal]).itemsize

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -44,6 +44,8 @@ Numpy types (> for BE)
 'U' Unicode string
 
 'V' raw data (void)
+
+'var' variable-size (non-numpy). Checks the data type from elsewhere
 '''
 
 
@@ -611,8 +613,8 @@ class SystemValues(object):
                             }
                         }
                     },
-                    'UHF_SET_PIPE': {
-                        'what': 'Set the communication to the PIPE(transparent) mode',
+                    'UHF_SET_ECHO': {
+                        'what': 'Starts echo over UART',
                         'subPort': 42,
                         'inoutInfo': {
                             'args': None,
@@ -631,8 +633,8 @@ class SystemValues(object):
                             }
                         }
                     },
-                    'UHF_SET_ECHO': {
-                        'what': 'Starts echo over UART',
+                    'UHF_SET_PIPE': {
+                        'what': 'Set the communication to the PIPE(transparent) mode',
                         'subPort': 44,
                         'inoutInfo': {
                             'args': None,

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -291,7 +291,6 @@ class SystemValues(object):
                                 'Battery Voltage': '>f',
                                 'Power Amplifier Current': '>f',
                                 'Power Amplifier Voltage': '>f',
-                                'Firmware Version': '>f',
                             }
                         }
                     },
@@ -447,7 +446,7 @@ class SystemValues(object):
                         'what': 'Sets UHF destination callsign',
                         'subPort': 28,
                         'inoutInfo': {
-                            'args': ['>U6'],
+                            'args': ['>S6'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -457,7 +456,7 @@ class SystemValues(object):
                         'what': 'Sets UHF source callsign',
                         'subPort': 29,
                         'inoutInfo': {
-                            'args': ['>U6'],
+                            'args': ['>S6'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -467,7 +466,7 @@ class SystemValues(object):
                         'what': 'Sets UHF morse code callsign (max 36)',
                         'subPort': 30,
                         'inoutInfo': {
-                            'args': ['>U36'],
+                            'args': ['>S36'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -478,7 +477,7 @@ class SystemValues(object):
                         'subPort': 31,
                         'inoutInfo': {
                             # increase packet size and switch to >U108
-                            'args': ['>U60'],
+                            'args': ['>S60'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -489,7 +488,7 @@ class SystemValues(object):
                         'subPort': 32,
                         'inoutInfo': {
                             # Switch to >U97 after packet configuration
-                            'args': ['>U60'],
+                            'args': ['>S60'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -509,7 +508,7 @@ class SystemValues(object):
                         'what': 'Sets UHF FRAM address and write 16-byte data',
                         'subPort': 34,
                         'inoutInfo': {
-                            'args': ['>u4', '>U16'],
+                            'args': ['>u4', '>S16'],
                             'returns': {
                                 'err': '>b',
                             }
@@ -566,8 +565,8 @@ class SystemValues(object):
                             'args': None,
                             'returns': {
                                 'err': '>b',
-                                'Destination': '>U6',
-                                'Source': '>U6',
+                                'Destination': '>S6',
+                                'Source': '>S6',
                             }
                         }
                     },
@@ -578,7 +577,7 @@ class SystemValues(object):
                             'args': None,
                             'returns': {
                                 'err': '>b',
-                                'Morse': '>U36',
+                                'Morse': '>S36',
                             }
                         }
                     },
@@ -589,7 +588,7 @@ class SystemValues(object):
                             'args': None,
                             'returns': {
                                 'err': '>b',
-                                'MIDI': '>U60',
+                                'MIDI': '>S60',
                             }
                         }
                     },
@@ -600,7 +599,7 @@ class SystemValues(object):
                             'args': None,
                             'returns': {
                                 'err': '>b',
-                                'Beacon Message': '>U60',
+                                'Beacon Message': '>S60',
                             }
                         }
                     },
@@ -611,7 +610,7 @@ class SystemValues(object):
                             'args': ['>u4'],
                             'returns': {
                                 'err': '>b',
-                                'FRAM': '>U16',
+                                'FRAM': '>S16',
                             }
                         }
                     },

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -655,19 +655,55 @@ class SystemValues(object):
                         'what': 'Gets config values in active mode for a specific type',
                         'subPort': 0,
                         'inoutInfo': {
-                            'args': ['<u2', '<u1'],
+                            'args': ['<u2', '<u1'], #id, type_id
                             'returns': {
                                 'err': '>B',
                                 'type': '<u1',
-                                'Value': '<u1' #?
+                                'Value': 'var' #In command parser it gets the data type from the return value for 'type'
                             }
                         }
-                    },                                                              
+                    },   
+                    'GET_MAIN_CONFIG': {
+                        'what': 'Gets config values in active mode for a specific type',
+                        'subPort': 1,
+                        'inoutInfo': {
+                            'args': ['<u2', '<u1'], #id, type_id
+                            'returns': {
+                                'err': '>B',
+                                'type': '<u1',
+                                'Value': 'var' #See comment for active
+                            }
+                        }
+                    },  
+                    'GET_FALLBACK_CONFIG': {
+                        'what': 'Gets config values in active mode for a specific type',
+                        'subPort': 2,
+                        'inoutInfo': {
+                            'args': ['<u2', '<u1'], #id, type_id
+                            'returns': {
+                                'err': '>B',
+                                'type': '<u1',
+                                'Value': 'var' #See comment for active
+                            }
+                        }
+                    },
+                    'GET_DEFAULT_CONFIG': {
+                        'what': 'Gets config values in active mode for a specific type',
+                        'subPort': 3,
+                        'inoutInfo': {
+                            'args': ['<u2', '<u1'], #id, type_id
+                            'returns': {
+                                'err': '>B',
+                                'type': '<u1',
+                                'Value': 'var' #See comment for active
+                            }
+                        }
+                    },                                                                                                                      
                     'SET_CONFIG': {
                         'what': 'Sets the configuration',
                         'subPort': 4,
                         'inoutInfo': {
-                            'args': ['<u2', '<u1', '<u1'], #id, type, config
+                            'args': ['<u2', '<u1', 'var'], #id, type, config
                             'returns': {
                                 'err': '>B',
                             }
@@ -1066,9 +1102,9 @@ class SystemValues(object):
                 'subservice':{
                     'SOFT': {                	
                         'what': 'Does a soft reset on EPS (reboot)',
-                        'subPort': 128, #with key: 491527
+                        'subPort': 128,
                         'inoutInfo': {
-                            'args': ['<u4'],  # 2147975175
+                            'args': ['<u4'],  # 491527 or 2147975175
                             'returns': {
                                 'err': '>b',
                             }

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -552,9 +552,6 @@ class SystemValues(object):
                                 'Packets in': '>u4',
                                 'Packets in CRC16': '>u4',
                                 'Temperature': '>f',
-                                'Low power status': '>u1',
-                                'Payload Size': '>u2',
-                                'Secure key': '>u4',
                             }
                         }
                     },
@@ -641,6 +638,17 @@ class SystemValues(object):
                             'args': None,
                             'returns': {
                                 'err': '>b',
+                            }
+                        }
+                    },
+                    'UHF_GET_SECURE_KEY': {
+                        'what': 'Gets the key for secure mode',
+                        'subPort': 45,
+                        'inoutInfo': {
+                            'args': None,
+                            'returns': {
+                                'err': '>b',
+                                'Secure Key': '>u4',
                             }
                         }
                     },

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -671,7 +671,7 @@ class SystemValues(object):
                         }
                     },   
                     'GET_MAIN_CONFIG': {
-                        'what': 'Gets config values in active mode for a specific type',
+                        'what': 'Gets config values in main mode for a specific type',
                         'subPort': 1,
                         'inoutInfo': {
                             'args': ['<u2', '<u1'], #id, type_id
@@ -683,7 +683,7 @@ class SystemValues(object):
                         }
                     },  
                     'GET_FALLBACK_CONFIG': {
-                        'what': 'Gets config values in active mode for a specific type',
+                        'what': 'Gets config values in fallback mode for a specific type',
                         'subPort': 2,
                         'inoutInfo': {
                             'args': ['<u2', '<u1'], #id, type_id
@@ -695,7 +695,7 @@ class SystemValues(object):
                         }
                     },
                     'GET_DEFAULT_CONFIG': {
-                        'what': 'Gets config values in active mode for a specific type',
+                        'what': 'Gets config values in default mode for a specific type',
                         'subPort': 3,
                         'inoutInfo': {
                             'args': ['<u2', '<u1'], #id, type_id
@@ -1101,7 +1101,7 @@ class SystemValues(object):
                 }
             },
 
-            'REBOOT': { # Does not work atm!
+            'REBOOT': {
                 'port': 4,  # As per CSP docs
                 # EPS soft reset
                 # Not recommended to use by the operator

--- a/src/groundStation/system.py
+++ b/src/groundStation/system.py
@@ -936,11 +936,16 @@ class SystemValues(object):
                 # EPS soft reset
                 # Not recommended to use by the operator
                 # no subport (command ID) needed.
-                'what': 'Does a soft reset on EPS (reboot)',
-                'inoutInfo': {
-                    'args': ['<u4'],  # 2147975175
-                    'returns': {
-                        'err': '>b',
+                'subservice':{
+                    'SOFT': {                	
+                        'what': 'Does a soft reset on EPS (reboot)',
+                        'subPort': 128, #with key: 491527
+                        'inoutInfo': {
+                            'args': ['<u4'],  # 2147975175
+                            'returns': {
+                                'err': '>b',
+                            }
+                        }
                     }
                 }
                 # magic number 0x80078007 must be sent with csp port 4 and no subport number

--- a/test/test_sband.py
+++ b/test/test_sband.py
@@ -30,7 +30,7 @@ def testAllCommandsToOBC():
     test.sendAndExpect('obc.communication.s_get_control',
                   {'err': 0, 'status': 0, 'mode': 0})
     test.sendAndExpect('obc.communication.s_get_full_status', {'err': 0, 'PWRGD': 1, 'TXL': 1, 'Transmit Ready': 1, 'Buffer Count': 0, 'Buffer Underrun': 1, 'Buffer Overrun': 2, 'Output Power': np.float32(26), 'Power Amplifier Temperature': np.float32(
-        27.3), 'Top Temperature': np.float32(-2.8), 'Bottom Temperature': np.float32(11.7), 'Battery Current': np.float32(95), 'Battery Voltage': np.float32(7.2), 'Power Amplifier Current': np.float32(0.48), 'Power Amplifier Voltage': np.float32(5.1), 'Firmware Version': np.float32(7.14)})
+        27.3), 'Top Temperature': np.float32(-2.8), 'Bottom Temperature': np.float32(11.7), 'Battery Current': np.float32(95), 'Battery Voltage': np.float32(7.2), 'Power Amplifier Current': np.float32(0.48), 'Power Amplifier Voltage': np.float32(5.1)})
     test.sendAndExpect('obc.communication.s_set_freq(2250.5)', {'err': 0})
     test.sendAndExpect('obc.communication.s_get_freq', {
                   'err': 0, 'frequency': np.float32(2250.5)})

--- a/test/uhf/test_uhf.py
+++ b/test/uhf/test_uhf.py
@@ -46,19 +46,19 @@ def testAllCommandsToOBC():
     test.sendAndExpect('obc.communication.uhf_set_source(UX1UHF)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_set_destination(cq12AB)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_callsign', {
-                  'err': 0, 'Destination': 'CQ12AB', 'Source': 'UX1UHF'})
+                  'err': 0, 'Destination': b'CQ12AB', 'Source': b'UX1UHF'})
     test.sendAndExpect(
         'obc.communication.uhf_set_morse(--.|--|..-|.---|.|.-.-|.-..|-.|--..)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_morse', {
-                  'err': 0, 'Morse': '--. -- ..- .--- . .-.- .-.. -. --..'})
+                  'err': 0, 'Morse': b'--. -- ..- .--- . .-.- .-.. -. --..'})
     # 67H69H71H67H67H69H71H67H71H72H74W71H72H74W
-    test.sendAndExpect('obc.communication.uhf_set_midi(H67H69H71H)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_set_midi(M67H69H71H)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_midi',
-                  {'err': 0, 'MIDI': 'H67H69H71H'})
+                  {'err': 0, 'MIDI': b'67H69H71H'})
     test.sendAndExpect(
         'obc.communication.uhf_set_beacon_msg(HelloAlbertaSat)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_beacon_msg', {
-                  'err': 0, 'Beacon Message': 'HELLOALBERTASAT'})
+                  'err': 0, 'Beacon Message': b'HELLOALBERTASAT'})
     test.sendAndExpect('obc.communication.uhf_set_pipe', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_set_bcn', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_set_echo', {'err': 0})

--- a/test/uhf/test_uhf.py
+++ b/test/uhf/test_uhf.py
@@ -42,7 +42,7 @@ def testAllCommandsToOBC():
     test.sendAndExpect('obc.communication.uhf_restore(1)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_secure(1)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_full_stat', {'err': 0, 'HFXT': 0, 'UartBaud': 1, 'Reset': 0, 'RF Mode': 3, 'Echo': 0, 'BCN': 0, 'PIPE': 0, 'Bootloader': 0, 'CTS': 0, 'SEC': 1, 'FRAM': 0, 'RFTS': 0, 'Frequency': 436000000,
-                                                          'PIPE timeout': 30, 'Beacon period': 89, 'Audio trans. period': 536, 'Uptime': 12, 'Packets out': 100, 'Packets in': 70, 'Packets in CRC16': 10, 'Temperature': np.float32(18.4), 'Low power status': 0, 'Payload Size': 127, 'Secure key': 32})
+                                                          'PIPE timeout': 30, 'Beacon period': 89, 'Audio trans. period': 536, 'Uptime': 12, 'Packets out': 100, 'Packets in': 70, 'Packets in CRC16': 10, 'Temperature': np.float32(18.4)})
     test.sendAndExpect('obc.communication.uhf_set_source(UX1UHF)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_set_destination(cq12AB)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_callsign', {
@@ -65,7 +65,7 @@ def testAllCommandsToOBC():
     test.sendAndExpect(
         'obc.communication.uhf_set_params(437500000 45 60 70)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_full_stat', {'err': 0, 'HFXT': 0, 'UartBaud': 1, 'Reset': 0, 'RF Mode': 3, 'Echo': 1, 'BCN': 1, 'PIPE': 1, 'Bootloader': 0, 'CTS': 0, 'SEC': 1, 'FRAM': 0, 'RFTS': 0, 'Frequency': 437500000,
-                                                          'PIPE timeout': 45, 'Beacon period': 60, 'Audio trans. period': 70, 'Uptime': 12, 'Packets out': 100, 'Packets in': 70, 'Packets in CRC16': 10, 'Temperature': np.float32(18.4), 'Low power status': 0, 'Payload Size': 127, 'Secure key': 32})
+                                                          'PIPE timeout': 45, 'Beacon period': 60, 'Audio trans. period': 70, 'Uptime': 12, 'Packets out': 100, 'Packets in': 70, 'Packets in CRC16': 10, 'Temperature': np.float32(18.4)})
     test.sendAndExpect('obc.communication.uhf_set_I2C(23)', {'err': 0})
 
     test.summary() #call when done to print summary of tests

--- a/test/uhf/test_uhf.py
+++ b/test/uhf/test_uhf.py
@@ -48,9 +48,9 @@ def testAllCommandsToOBC():
     test.sendAndExpect('obc.communication.uhf_get_callsign', {
                   'err': 0, 'Destination': 'CQ12AB', 'Source': 'UX1UHF'})
     test.sendAndExpect(
-        'obc.communication.uhf_set_morse(--.--..-.---..-.-.-..-.--..-..--)', {'err': 0})
+        'obc.communication.uhf_set_morse(--.|--|..-|.---|.|.-.-|.-..|-.|--..)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_morse', {
-                  'err': 0, 'Morse': '--.--..-.---..-.-.-..-.--..-..--'})
+                  'err': 0, 'Morse': '--. -- ..- .--- . .-.- .-.. -. --..'})
     # 67H69H71H67H67H69H71H67H71H72H74W71H72H74W
     test.sendAndExpect('obc.communication.uhf_set_midi(H67H69H71H)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_midi',


### PR DESCRIPTION
The changes include adding configuration commands for EPS, removing some useless commands/parameters from commands. Also, the command parser was updated to allow setting UHF morse beacon message and eps config commands with variable-size data types.
All the updated commands have been tested with the hardware.
CommandDocs and test scripts have been updated with the changes.