### PR TITLE
New test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
     "csp:install": "cd libcsp && sudo python3 waf install",
     "build": "yarn build:env && yarn csp:clone && yarn csp:configure && yarn csp:build",
     "run:cli": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 src/cli.py",
-    "run:test_sband": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_sband.py",
+    "run:test_sband": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/sband/test_sband.py",
     "run:test_uhf": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/uhf/test_uhf.py",
-    "run:test_updater": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_updater.py"
+    "run:test_updater": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_updater.py",
+    "run:test_uhf_hardware": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/uhf/test_uhf_hardware.py",
+    "run:test_sband_hardware": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/sband/test_sband_hardware.py",
+    "run:test_eps": "sudo LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_eps.py"
   }
 }

--- a/test/sband/test_sband.py
+++ b/test/sband/test_sband.py
@@ -21,6 +21,11 @@
 
 
 import numpy as np
+
+import sys
+from os import path
+sys.path.append("./test")
+
 from testLib import testLib as test
 
 test = test() #call to initialize local test class

--- a/test/sband/test_sband_hardware.py
+++ b/test/sband/test_sband_hardware.py
@@ -1,0 +1,50 @@
+'''
+ * Copyright (C) 2020  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file test_sband.py
+ * @author Andrew Rooney, Arash Yazdani
+ * @date 2020-11-20
+'''
+
+'''  to run > yarn run:test_sband -I uart -d /dev/ttyUSB0 '''
+
+''' The goal of this test is to run commands that are safe with the Sband hardware and does not change critical configurations'''
+
+import numpy as np
+
+import sys
+from os import path
+sys.path.append("./test")
+
+from testLib import testLib as test
+
+test = test() #call to initialize local test class
+
+def testAllCommandsToOBC():
+    test.sendAndExpect('obc.communication.s_set_control(0 0)', {'err': 0})
+    test.sendAndExpect('obc.communication.s_get_control',
+                  {'err': 0, 'status': 0, 'mode': 0})
+    test.send('obc.communication.s_get_full_status')
+    test.send('obc.communication.s_get_freq')
+    test.sendAndExpect('obc.communication.s_set_papower(24)', {'err': 0})
+    test.sendAndExpect('obc.communication.s_get_papower', {
+                  'err': 0, 'Power Amplifier Power': 24})
+    test.send('obc.communication.s_get_encoder')
+    test.sendAndExpect('obc.communication.s_get_buffer(0)', {'err': 0, 'buffer': 0})
+    test.send('obc.communication.s_get_hk')
+    
+    test.summary() #call when done to print summary of tests
+
+if __name__ == '__main__':
+    testAllCommandsToOBC()

--- a/test/testLib.py
+++ b/test/testLib.py
@@ -54,6 +54,22 @@ class testLib(object):
             '\n\tRecieved: ' + str(response) +
             '\n\tExpected: ' + str(expect) + '\n\n' + '\033[0m')
         return response == expect
+
+    def send(self, send):
+        server, port, toSend = gs.getInput(inVal = send)
+        response = gs.transaction(server, port, toSend)
+        if response != {}:
+            testpassed = 'Pass'
+            colour = '\033[92m' #green
+            self.passed += 1
+        else:
+            testpassed = 'Fail'
+            colour = '\033[91m' #red
+            self.failed += 1
+
+        print(colour + ' - TEST CASE ' + testpassed + ' -\n\tSent: ' + send +
+            '\n\tRecieved: ' + str(response) + '\n\n' + '\033[0m')
+        return True
     
     def summary(self):
         delta = time.time() - self.start

--- a/test/test_eps.py
+++ b/test/test_eps.py
@@ -1,0 +1,39 @@
+'''
+ * Copyright (C) 2021  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file test_eps.py
+ * @author Arash Yazdani
+ * @date 2021-08-25
+'''
+
+'''  to run > yarn run:test_eps -I uart -d /dev/ttyUSB0 '''
+
+
+import numpy as np
+from testLib import testLib as test
+
+test = test() #call to initialize local test class
+
+def testAllCommandsToOBC():
+    test.send('eps.time_management.get_eps_time')
+    test.sendAndExpect('eps.control.single_output_control(10 1 0)', {'err': 0}) #Preferably a channe that does not power a subsystem
+    test.send('eps.cli.general_telemetry')
+    test.sendAndExpect('eps.control.single_output_control(10 0 0)', {'err': 0})
+    test.sendAndExpect('eps.configuration.get_active_config(0 0))', {'err': 0, 'type':0, 'Value': 4})
+    test.sendAndExpect('eps.configuration.get_active_config(136 2))', {'err': 0, 'type':2, 'Value': 500}) #Might change though. Just checking another type
+    
+    test.summary() #call when done to print summary of tests
+
+if __name__ == '__main__':
+    testAllCommandsToOBC()

--- a/test/test_eps.py
+++ b/test/test_eps.py
@@ -30,8 +30,8 @@ def testAllCommandsToOBC():
     test.sendAndExpect('eps.control.single_output_control(10 1 0)', {'err': 0}) #Preferably a channe that does not power a subsystem
     test.send('eps.cli.general_telemetry')
     test.sendAndExpect('eps.control.single_output_control(10 0 0)', {'err': 0})
-    test.sendAndExpect('eps.configuration.get_active_config(0 0))', {'err': 0, 'type':0, 'Value': 4})
-    test.sendAndExpect('eps.configuration.get_active_config(136 2))', {'err': 0, 'type':2, 'Value': 500}) #Might change though. Just checking another type
+    test.sendAndExpect('eps.configuration.get_active_config(0 0)', {'err': 0, 'type':0, 'Value': 4})
+    test.sendAndExpect('eps.configuration.get_active_config(136 2)', {'err': 0, 'type':2, 'Value': 500}) #Might change though. Just checking another type
     
     test.summary() #call when done to print summary of tests
 

--- a/test/uhf/test_uhf_hardware.py
+++ b/test/uhf/test_uhf_hardware.py
@@ -46,10 +46,6 @@ def testAllCommandsToOBC():
     test.sendAndExpect('obc.communication.uhf_set_midi(M67H69H71H)', {'err': 0})
     test.sendAndExpect('obc.communication.uhf_get_midi',
                   {'err': 0, 'MIDI': b'67H69H71H'})
-    test.sendAndExpect(
-        'obc.communication.uhf_set_beacon_msg(HelloAlbertaSat)', {'err': 0})
-    test.sendAndExpect('obc.communication.uhf_get_beacon_msg', {
-                  'err': 0, 'Beacon Message': b'HELLOALBERTASAT'})
     test.sendAndExpect('obc.communication.uhf_set_bcn', {'err': 0})
 
     test.summary() #call when done to print summary of tests

--- a/test/uhf/test_uhf_hardware.py
+++ b/test/uhf/test_uhf_hardware.py
@@ -1,0 +1,59 @@
+'''
+ * Copyright (C) 2021  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file test_uhf_hardware.py
+ * @author Arash Yazdani
+ * @date 2021-08-25
+'''
+
+'''  to run > yarn run:test_uhf_hardware -I uart -d /dev/ttyUSB0 '''
+
+''' The goal of this test is to run commands that are safe with the uhf hardware and does not change critical configurations'''
+
+import numpy as np
+
+import sys
+from os import path
+sys.path.append("./test")
+
+from testLib import testLib as test
+
+test = test() #call to initialize local test class
+
+
+
+def testAllCommandsToOBC():
+    test.send('obc.communication.uhf_get_full_stat')
+    test.sendAndExpect('obc.communication.uhf_set_source(UX1UHF)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_set_destination(cq12AB)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_get_callsign', {
+                  'err': 0, 'Destination': b'CQ12AB', 'Source': b'UX1UHF'})
+    test.sendAndExpect(
+        'obc.communication.uhf_set_morse(--.|--|..-|.---|.|.-.-|.-..|-.|--..)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_get_morse', {
+                  'err': 0, 'Morse': b'--. -- ..- .--- . .-.- .-.. -. --..'})
+    test.sendAndExpect('obc.communication.uhf_set_midi(M67H69H71H)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_get_midi',
+                  {'err': 0, 'MIDI': b'67H69H71H'})
+    test.sendAndExpect(
+        'obc.communication.uhf_set_beacon_msg(HelloAlbertaSat)', {'err': 0})
+    test.sendAndExpect('obc.communication.uhf_get_beacon_msg', {
+                  'err': 0, 'Beacon Message': b'HELLOALBERTASAT'})
+    test.sendAndExpect('obc.communication.uhf_set_bcn', {'err': 0})
+
+    test.summary() #call when done to print summary of tests
+
+
+if __name__ == '__main__':
+    testAllCommandsToOBC()


### PR DESCRIPTION
A modified UHF and Sband test scripts were added that run some safe commands without changing major configurations. It could be used throughout flatsat testing to confirm everything is on track.
An eps test script with the same considerations has also been added. The latter satisfies this [clickup task](https://app.clickup.com/t/175wnpk). 