### PR TITLE
Workflow no longer errors when no changes are committed

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -26,5 +26,5 @@ jobs:
           git config --global user.name github-actions &&
           git config --global user.email github-actions@github.com &&
           git add CommandDocs.txt &&
-          git commit -m "Auto-updating CommandDocs.txt" &&
+          git commit -m "Auto-updating CommandDocs.txt" || exit 0 &&
           git push


### PR DESCRIPTION
This should fix cases where the workflow errors out when no changes are made to CommandDocs.txt