### PR TITLE
Updated imports so the website's comm.py can use cliGroundStation

### DIFF
--- a/src/groundStation/__init__.py
+++ b/src/groundStation/__init__.py
@@ -1,4 +1,5 @@
 try:
     from ex2_ground_station_software.src.groundStation import groundStation
+    from ex2_ground_station_software.src.groundStation import cliGroundStation
 except ModuleNotFoundError:
     pass

--- a/src/groundStation/cliGroundStation.py
+++ b/src/groundStation/cliGroundStation.py
@@ -16,18 +16,33 @@
  * @author Robert Taylor
  * @date 2021-12-21
 """
-from groundStation import groundStation
-from groundStation.commandParser import cliCommandParser
-import libcsp_py3 as libcsp
+try: # We are using this file through the website (comm.py)
+    from ex2_ground_station_software.src.groundStation import groundStation
+    from ex2_ground_station_software.src.groundStation.commandParser import cliCommandParser
+    import libcsp.build.libcsp_py3 as libcsp
+except: # We are using this file through sat_cli.py
+    from groundStation import groundStation
+    from groundStation.commandParser import cliCommandParser
+    import libcsp_py3 as libcsp
 
 class cliGroundStation(groundStation.groundStation):
     def __init__(self, opts):
         super().__init__(opts)
         self.parser = cliCommandParser()
 
+    def __dummy_resp__(self, server, port, buf):
+        """ Generates a dummy string response for a sat_cli command. """
+        return "Server: {} | Port: {} | Buffer: {}".format(
+            server,
+            port,
+            str(libcsp.packet_get_data(buf), "ascii").strip().strip("\x00")
+        )
+
     def transaction(self, server, port, buf):
         """ Execute CSP transaction - send and receive on one RDP connection and
         return parsed packet """
+        if self.dummy:
+            return str(self.__dummy_resp__(server, port, buf))
         conn = self.__connectionManager__(server, port)
         if conn is None:
             print('Error: Could not connection')
@@ -48,4 +63,3 @@ class cliGroundStation(groundStation.groundStation):
             if data[1] == 0:
                 break
         return response.strip()
-        


### PR DESCRIPTION
Also added a dummy response to the cliGroundStation when the interface is set to 'dummy': `-I dummy`.

Import changes are identical to #73 so it should still work without the website