### PR TITLE
Enable CRC32 on connections

### DIFF
--- a/src/groundStation/groundStation.py
+++ b/src/groundStation/groundStation.py
@@ -145,7 +145,7 @@ class groundStation(object):
                 if server == 4:
                     conn = libcsp.connect(libcsp.CSP_PRIO_NORM, server, port, 1000, libcsp.CSP_O_CRC32)
                 else:
-                    conn = libcsp.connect(libcsp.CSP_PRIO_NORM, server, port, 1000000000, libcsp.CSP_SO_HMACREQ)
+                    conn = libcsp.connect(libcsp.CSP_PRIO_NORM, server, port, 1000000000, libcsp.CSP_SO_HMACREQ | libcsp.CSP_SO_CRC32REQ)
             except Exception as e:
                 print(e)
                 return None


### PR DESCRIPTION
CRC will be calculated on the satellite whether the satellite requires it or not, since the CRC bit is set, so responses will contain a CRC
The forward error correction will not detect errors if there are too many and will instead give wrong data. This change allows the transport layer to detect errors the data link layer could not