### PR TITLE
Jmmabanta/feature/website refactor integration

### DIFF
--- a/src/CSPHandler.py
+++ b/src/CSPHandler.py
@@ -58,7 +58,10 @@ class CSPHandler(object):
             self._sdr(device, libcsp.SDR_UHF_9600_BAUD)
         elif interface == 'sband':
             raise NotImplementedError("Sband support not yet implemented")
-    
+        elif interface == 'dummy':
+            self.interfaceName = "dummy"
+            return # Skip libcsp initialization when using dummy responses
+
         stringBuild = ""
         for node in SatelliteNodes:
             stringBuild = stringBuild + " {} {}, ".format(node.value, self.interfaceName)
@@ -109,7 +112,7 @@ class UHF_CSPHandler(CSPHandler):
             raise ValueError("UHF CSP handler works only with sdr interface")
         self.uTrns = uTransceiver()
         super().__init__(addr, interface, device, hmacKey)
-        
+
 
     def send(self, server, port, buf : bytearray):
         self.uTrns.handlePipeMode()

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,8 +30,14 @@ class cli(GroundStation):
                 transactObj = self.interactive.getTransactionObject(inStr, self.networkManager)
                 ret = transactObj.execute()
                 print()
-                for key, value in ret.items():
-                    print("{} : {}".format(key, value))
+                # Housekeeping data can be a list of dicts
+                if isinstance(ret, list):
+                    for entry in ret:
+                        for key, value in entry.items():
+                            print("{} : {}".format(key, value))
+                else:
+                    for key, value in ret.items():
+                        print("{} : {}".format(key, value))
                 print()
             except Exception as e:
                 print(e)

--- a/src/dummyUtils.py
+++ b/src/dummyUtils.py
@@ -17,6 +17,7 @@
  * @date 2022-07-30
 '''
 
+import random
 from system import services
 
 def generateFakeHKDict():
@@ -24,14 +25,18 @@ def generateFakeHKDict():
     """
     fake_hk = services['HOUSEKEEPING']['subservice']['GET_HK']['inoutInfo']['returns'].copy()
 
-    # Replace data types with default values
-    DEFAULT_INT = 7
-    DEFAULT_FLOAT = 12.34
+    # Replace data types with values
     for key in fake_hk:
-        if 'b' in fake_hk[key] or 'B' in fake_hk[key] or 'V' in fake_hk[key] \
-                or 'u' in fake_hk[key] or 'i' in fake_hk[key]:
-            fake_hk[key] = DEFAULT_INT
+        fake_uint = random.randint(0, 255)
+        fake_int = random.randint(-128, 127)
+        fake_float = random.uniform(-128.0, 127.0)
+        if 'B' in fake_hk[key] or 'u' in fake_hk[key] or 'V' in fake_hk[key]:
+            fake_hk[key] = fake_uint
+        elif 'b' in fake_hk[key] or 'i' in fake_hk[key]:
+            fake_hk[key] = fake_int
         elif 'f' in fake_hk[key]:
-            fake_hk[key] = DEFAULT_FLOAT
+            fake_hk[key] = fake_float
+        else:
+            raise NotImplementedError('Found data type not accounted for!')
 
     return fake_hk

--- a/src/dummyUtils.py
+++ b/src/dummyUtils.py
@@ -30,12 +30,15 @@ def generateFakeHKDict():
         fake_uint = random.randint(0, 255)
         fake_int = random.randint(-128, 127)
         fake_float = random.uniform(-128.0, 127.0)
+        fake_string = 'Test String!'
         if 'B' in fake_hk[key] or 'u' in fake_hk[key] or 'V' in fake_hk[key]:
             fake_hk[key] = fake_uint
         elif 'b' in fake_hk[key] or 'i' in fake_hk[key]:
             fake_hk[key] = fake_int
         elif 'f' in fake_hk[key]:
             fake_hk[key] = fake_float
+        elif 'U' in fake_hk[key]:
+            fake_hk[key] = fake_string
         else:
             raise NotImplementedError('Found data type not accounted for!')
 

--- a/src/dummyUtils.py
+++ b/src/dummyUtils.py
@@ -1,0 +1,37 @@
+'''
+ * Copyright (C) 2022  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file dummyUtils.py
+ * @author John Mabanta
+ * @date 2022-07-30
+'''
+
+from system import services
+
+def generateFakeHKDict():
+    """Returns a fake housekeeping dictionary for dummy responses
+    """
+    fake_hk = services['HOUSEKEEPING']['subservice']['GET_HK']['inoutInfo']['returns'].copy()
+
+    # Replace data types with default values
+    DEFAULT_INT = 7
+    DEFAULT_FLOAT = 12.34
+    for key in fake_hk:
+        if 'b' in fake_hk[key] or 'B' in fake_hk[key] or 'V' in fake_hk[key] \
+                or 'u' in fake_hk[key] or 'i' in fake_hk[key]:
+            fake_hk[key] = DEFAULT_INT
+        elif 'f' in fake_hk[key]:
+            fake_hk[key] = DEFAULT_FLOAT
+
+    return fake_hk

--- a/src/groundStation.py
+++ b/src/groundStation.py
@@ -37,7 +37,7 @@ class GroundStation:
             exit(1)
 
         keyfile.close()
-        self.interactive = InteractiveHandler()
+        self.interactive = InteractiveHandler(opts.interface == "dummy")
         self.inputHandler = InputHandler()
         self.setSatellite(opts.satellite)
 

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -42,13 +42,7 @@ class InteractiveHandler:
         # TODO: Make this less bad after fixing inputParser badness
         tokens = self.inParser.lexer(command)
         if self.dummy:
-            if tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] == "GET_HK":
-                transactObj = dummyHKTransaction(command, networkHandler, self.fake_hk_id)
-                self.fake_hk_id += 1
-            elif tokens[self.serviceIdx] == "CLI":
-                transactObj = dummySatCliTransaction(command, networkHandler)
-            else:
-                transactObj = dummyTransaction(command, networkHandler)
+            transactObj = self.getDummyTransactionObject(command, networkHandler)
         elif tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] == "GET_HK":
             transactObj = getHKTransaction(command, networkHandler)
         elif tokens[self.serviceIdx] == "CLI":
@@ -60,6 +54,18 @@ class InteractiveHandler:
         else:
             transactObj = baseTransaction(command, networkHandler)
 
+        return transactObj
+
+    def getDummyTransactionObject(self, command: str, networkHandler):
+        transactObj = None
+        tokens = self.inParser.lexer(command)
+        if tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] == "GET_HK":
+            transactObj = dummyHKTransaction(command, networkHandler, self.fake_hk_id)
+            self.fake_hk_id += 1
+        elif tokens[self.serviceIdx] == "CLI":
+            transactObj = dummySatCliTransaction(command, networkHandler)
+        else:
+            transactObj = dummyTransaction(command, networkHandler)
         return transactObj
 
 class baseTransaction:
@@ -110,7 +116,6 @@ class setTimeTransaction(baseTransaction):
         self.args = self.pkt['args']
         self.send()
         return self.parseReturnValue(self.receive())
-
 
 class schedulerTransaction(baseTransaction):
     def execute(self):

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -43,7 +43,7 @@ class InteractiveHandler:
         tokens = self.inParser.lexer(command)
         if self.dummy:
             transactObj = self.getDummyTransactionObject(command, networkHandler)
-        elif tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] == "GET_HK":
+        elif tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] in ["GET_HK", "GET_INSTANT_HK"]:
             transactObj = getHKTransaction(command, networkHandler)
         elif tokens[self.serviceIdx] == "CLI":
             transactObj = satcliTransaction(command, networkHandler)
@@ -61,7 +61,7 @@ class InteractiveHandler:
     def getDummyTransactionObject(self, command: str, networkHandler):
         transactObj = None
         tokens = self.inParser.lexer(command)
-        if tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] == "GET_HK":
+        if tokens[self.serviceIdx] == "HOUSEKEEPING" and tokens[self.subserviceIdx] in ["GET_HK", "GET_INSTANT_HK"]:
             transactObj = dummyHKTransaction(command, networkHandler, self.fake_hk_id)
             self.fake_hk_id += 1
         elif tokens[self.serviceIdx] == "CLI":

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -64,6 +64,8 @@ class InteractiveHandler:
             self.fake_hk_id += 1
         elif tokens[self.serviceIdx] == "CLI":
             transactObj = dummySatCliTransaction(command, networkHandler)
+        elif tokens[self.serviceIdx] == "SCHEDULER" and (tokens[self.subserviceIdx] in ['SET_SCHEDULE', 'DELETE_SCHEDULE', 'REPLACE_SCHEDULE']):
+            transactObj = dummySchedulerTransaction(command, networkHandler)
         else:
             transactObj = dummyTransaction(command, networkHandler)
         return transactObj
@@ -125,6 +127,21 @@ class schedulerTransaction(baseTransaction):
         self.args = packetEmbedder.embedCSP()
         self.send()
         return self.parseReturnValue(self.receive())
+
+class dummySchedulerTransaction(baseTransaction):
+    def execute(self):
+        tokens = self.inputParse.lexer(self.command)
+        file_param = tokens[-2]
+        f = open(file_param, "r")
+        cmdList = f.readlines()
+        packetEmbedder = EmbedPacket(cmdList, self.args)
+        self.args = packetEmbedder.embedCSP()
+        return {
+            'err': 0,
+            'dst': self.dst,
+            'dport': self.dport,
+            'args': self.args
+        }
 
 class getHKTransaction(baseTransaction):
     def execute(self):

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -95,12 +95,10 @@ class baseTransaction:
 
 class dummyTransaction(baseTransaction):
     def execute(self):
-        pkt = self.inputParse.parseInput(self.command)
         return {
-            'dst': pkt['dst'],
-            'dport': pkt['dport'],
-            'subservice': pkt['subservice'],
-            'args': pkt['args']
+            'dst': self.dst,
+            'dport': self.dport,
+            'args': self.args
         }
 
 class setTimeTransaction(baseTransaction):
@@ -172,12 +170,10 @@ class satcliTransaction(baseTransaction):
 
 class dummySatCliTransaction(satcliTransaction):
     def execute(self):
-        pkt = self.inputParse.parseInput(self.command)
         response = """Running as SatCli command \
             | dst: {} \
             | dport: {} \
-            | subservice: {} \
             | args: {}""".format(
-            pkt["dst"], pkt["dport"], pkt["subservice"], pkt["args"]
+            self.dst, self.dport, self.args
         )
         return response

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -121,8 +121,8 @@ class schedulerTransaction(baseTransaction):
     def execute(self):
         tokens = self.inputParse.lexer(self.command)
         file_param = tokens[-2]
-        f = open(file_param, "r")
-        cmdList = f.readlines()
+        with open(file_param, "r") as f:
+            cmdList = f.readlines()
         packetEmbedder = EmbedPacket(cmdList, self.args)
         self.args = packetEmbedder.embedCSP()
         self.send()
@@ -132,8 +132,8 @@ class dummySchedulerTransaction(baseTransaction):
     def execute(self):
         tokens = self.inputParse.lexer(self.command)
         file_param = tokens[-2]
-        f = open(file_param, "r")
-        cmdList = f.readlines()
+        with open(file_param, "r") as f:
+            cmdList = f.readlines()
         packetEmbedder = EmbedPacket(cmdList, self.args)
         self.args = packetEmbedder.embedCSP()
         return {


### PR DESCRIPTION
Added support for faking responses when using 'dummy' as an interface (`-I dummy`).

Luckily, I've found a way to modify the system path variable (temporarily) when running the website's communication script so that the imports are able to work without any modification!

I've also modified cli.py to mimic the [old version](https://github.com/AlbertaSat/ex2_ground_station_software/blob/e80e1b1478b2a30415fd62c4655be953a79d80f3/src/cli.py#L65) where--if given a list of dictionaries--would pretty print each one out. Apparently, the HOUSEKEEPING.GET_HK command can return multiple dictionaries as a list depending on the arguments (though I could be wrong and this behavior could've changed).