### PR TITLE
Ensure no whitespace/newline chars in scheduledCmd

### DIFF
--- a/src/embedCSP.py
+++ b/src/embedCSP.py
@@ -42,7 +42,7 @@ class EmbedPacket:
                 scheduledTime = self.cmdList[i][:cmdStart]
                 scheduledTime = " ".join(scheduledTime.strip().split())
                 ascii_values = [ord(character) for character in scheduledTime]
-                scheduledCmd = self.cmdList[i][cmdStart:]
+                scheduledCmd = self.cmdList[i][cmdStart:].strip()
 
                 command = self.inputParse.parseInput(scheduledCmd)
                 command['time'] = ascii_values


### PR DESCRIPTION
When reading a file with `readlines()`, python keeps the newline character `\n` at the end of each line in the list. This change strips these characters (as well as any other extraneous whitespace at the beginning and end of a command) so that scheduler commands can be parsed correctly.