### PR TITLE
Remove timeouts from connections

### DIFF
--- a/src/connectionManager.py
+++ b/src/connectionManager.py
@@ -24,16 +24,9 @@ from collections import defaultdict
 class ConnectionManager:
     def __init__(self):
         self.server_connection = defaultdict(dict)
-        self.rdp_timeout = 10000
+
     def getConn(self, server, port):
-        # TODO: This is bad
-        current = time.time()
-        timeout = self.rdp_timeout / 1000
-        if server not in self.server_connection or port not in self.server_connection[
-                server] or self.server_connection[server][port]['time initialized'] + timeout <= current:
-            if server in self.server_connection and port in self.server_connection[
-                    server] and self.server_connection[server][port]['time initialized'] + timeout <= current:
-                libcsp.close(self.server_connection[server][port]['conn'])
+        if server not in self.server_connection or port not in self.server_connection[server]:
             try:
                 if server == 4:
                     conn = libcsp.connect(libcsp.CSP_PRIO_NORM, server, port, 1000, libcsp.CSP_O_CRC32)
@@ -43,9 +36,5 @@ class ConnectionManager:
                 print(e)
                 return None
 
-            self.server_connection[server][port] = {
-                'conn': conn,
-                'time initialized': time.time()
-            }
-
-        return self.server_connection[server][port]['conn']
+            self.server_connection[server][port] = conn
+        return self.server_connection[server][port]


### PR DESCRIPTION
This appears to fix the weird bug where FTP and updater would randomly stop receiving packets. Turns out it would stop at a regular interval which happened to be the timeout of this weird connection thing. Removed timeouts from the connections. Since we don't use CSP RDP, there's no harm in not closing connections