### PR TITLE
changed baud rate to use ground station delay between packets (0)

### DIFF
--- a/src/CSPHandler.py
+++ b/src/CSPHandler.py
@@ -55,7 +55,7 @@ class CSPHandler(object):
         if interface == 'uart':
             self.ser = self._uart(device)
         elif interface == 'uhf' or interface == "sdr":
-            self._uhf(device, libcsp.SDR_UHF_9600_BAUD)
+            self._uhf(device, libcsp.SDR_UHF_GND_STATION_BAUD)
         elif interface == 'sband':
             self._sband()
         elif interface == 'dummy':

--- a/src/CSPHandler.py
+++ b/src/CSPHandler.py
@@ -55,7 +55,7 @@ class CSPHandler(object):
         if interface == 'uart':
             self.ser = self._uart(device)
         elif interface == 'uhf' or interface == "sdr":
-            self._uhf(device, libcsp.SDR_UHF_GND_STATION_BAUD)
+            self._uhf(device, libcsp.SDR_UHF_GNURADIO_BAUD)
         elif interface == 'sband':
             self._sband()
         elif interface == 'dummy':


### PR DESCRIPTION
GS transmit doesn't need delays between packets, so this speeds up file upload significantly.

Must be merged alongside respectively named PRs in libcsp and ex2_sdr.