### PR TITLE
scheduler

### DIFF
--- a/CommandDocs.txt
+++ b/CommandDocs.txt
@@ -21,41 +21,25 @@ SCHEDULER.SET_SCHEDULE:
 		port: 25		subport: 0
 
 
-SCHEDULER.GET_SCHEDULE:
-		About: Returns 0 and number of cmds left in the schedule on success.
+SCHEDULER.DELETE_SCHEDULE:
+		About: Deletes all scheduled tasks
+		Returns 0 on success, SchedulerError_t on error.
+		Refer to rederrno.h for reliance edge error codes
 		Supports: OBC
 		Arguments: None
 		return values: {'err': '>b'}
-		port: 25		subport: 1
-
-
-SCHEDULER.REPLACE_SCHEDULE:
-		About: Returns 0 and number of cmds left in the schedule on success.
-		Refer for schedule.h for calloc error code.
-		Refer to rederrno.h for reliance edge error codes
-		Supports: OBC
-		Arguments: None
-		return values: {'err': '>b', 'number of cmds scheduled': '>b'}
-		port: 25		subport: 2
-
-
-SCHEDULER.DELETE_SCHEDULE:
-		About: Deletes the tasks in the given schedule.
-		Returns 0 and number of cmds left in the schedule on success.
-		Refer for schedule.h for calloc error code.
-		Refer to rederrno.h for reliance edge error codes
-		Supports: OBC
-		Arguments: None
-		return values: {'err': '>b', 'number of cmds scheduled': '>b'}
 		port: 25		subport: 3
 
 
-SCHEDULER.PING_SCHEDULE:
-		About: Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes
+SCHEDULER.GET_SCHEDULE:
+		About: Retrieve the current schedule
+		On succes, Returns a count and summary of the scheduled commands
+		Returns SchedulerError_t on error.
+		Refer to rederrno.h for reliance edge error codes
 		Supports: OBC
 		Arguments: None
-		return values: {'err': '>b', 'number of cmds scheduled': '>b'}
-		port: 25		subport: 4
+		return values: {'err': '>b, 'count': '>b', 'cmds': 'var'}
+		port: 25		subport: 1
 
 
 SET_PIPE.UHF_GS_PIPE:

--- a/CommandDocs.txt
+++ b/CommandDocs.txt
@@ -11,34 +11,26 @@ CSP.PING:
 
 
 SCHEDULER.SET_SCHEDULE:
-		About: Uploads the schedule file and schedules the tasks to run.
-		Returns 0 and number of cmds left in the schedule on success.
-		Refer for schedule.h for calloc error code.
-		Refer to rederrno.h for reliance edge error codes
+		About: Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes
 		Supports: OBC
-		Arguments: { 'Schedule File': '<s128' }
-		return values: {'err': '>b', 'number of cmds scheduled': '>b'}
+		Arguments: None
+		return values: {'err': '>b', 'count': '>b'}
 		port: 25		subport: 0
 
 
 SCHEDULER.DELETE_SCHEDULE:
-		About: Deletes all scheduled tasks
-		Returns 0 on success, SchedulerError_t on error.
-		Refer to rederrno.h for reliance edge error codes
+		About: Returns 0 on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes
 		Supports: OBC
 		Arguments: None
-		return values: {'err': '>b'}
+		return values: {'err': '>b', 'red_errno': '>b'}
 		port: 25		subport: 3
 
 
 SCHEDULER.GET_SCHEDULE:
-		About: Retrieve the current schedule
-		On succes, Returns a count and summary of the scheduled commands
-		Returns SchedulerError_t on error.
-		Refer to rederrno.h for reliance edge error codes
+		About: Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes
 		Supports: OBC
 		Arguments: None
-		return values: {'err': '>b, 'count': '>b', 'cmds': 'var'}
+		return values: {'err': '>b', 'count': '>b', 'cmds': 'var'}
 		port: 25		subport: 1
 
 
@@ -2117,7 +2109,7 @@ NS_PAYLOAD.RESET_MCU:
 NS_PAYLOAD.NV_START:
 		About: Start transmitting voice data from filename. Blocksize should be a multiple of the blocksize of the codec and reasonably large (max 512)
 		Supports: OBC
-		Arguments: {'Repeats': '>u2', 'Blocksize': '>u2', 'Filename': '>S128'}
+		Arguments: {'CSP': '>b', 'Repeats': '>u1', 'Blocksize': '>u2', 'Filename': '>S128'}
 		return values: {'err': '>b'}
 		port: 22		subport: 11
 

--- a/SCHEDULER.md
+++ b/SCHEDULER.md
@@ -9,26 +9,45 @@ has a time specifying when to run and a task to run at that time. The format
 of the time specifier is:
 
 ```
-millisecond second minute hour weekday day month year
+millisecond second minute hour day month year
 ```
 
-The interpretation of most of the fields is obvious, except that `weekday` is
-the day of the week, with Sunday defined as 1, and `year` is the number of years
-since the *epoch* (January 1, 1970), so 2023 would be represented as 53.
+The interpretation of most of the fields is reasonably straight forward.
+Legal ranges for each field are:
+
+  |-------|-----------|
+  | msec | 0-999 |
+  | sec | 0-59 |
+  | min | 0-59 |
+  | hour | 0-23 |
+  | day | 1-31 |
+  | month | 1-12 |
+  | year | 2023-2026 |
+  | | or 23-26 |
+  |-------|-----------|
 
 The reason for this slightly curious format is to allow for periodic tasks.
 The `crontab(5)` man page covers a whole range of periodicity specifiers,
-for example:
+although we only support "wildcard" (`*`) and "step" (`/`). For example:
 
 ```
-# YukonSat play next audio file 30 minutes past every hour of 2023 
-0 0 30 * * * * 53 yk.audio.playback
+# YukonSat play next audio file 30 minutes past every hour of March 2023.
+0 0 30 * * 3 23 yk.audio.playback
 # AlbertaSat take an image every 5 minutes, every hour forever
-0 0 0-59/5 * * * * ex2.iris.capture
+0 0 */5 * * * ex2.iris.capture
 ```
 
-Currently, only the wildcard (`*`) is implemented but we can enhance the
-periodicity support as we understand our mission requirements better.
+The scheduler uses Unix UTC timestamps to schedule its tasks, and it is
+expected that we will synchronize the satellite's clock to earth's.
+The groundstation parses each cron spec into three timestamps:
+`first` is the timestamp of the first execution of the task;
+`period` is the repeat time in seconds;
+and `last` is the expiry or last execution of a periodic task.
+The cron format allows users to specify schedules that can be parsed
+into these 3 fields, however, if users find the format confusing or not
+expressive enough we can easily change it, since the parsing is done on
+the ground station.
 
-
-
+Note: as of February 2023 the `last` field is always 0, i.e. all periodic
+commands run forever. Until expiry is implemented, you can just delete a
+schedule that has finished.

--- a/src/interactiveHandler.py
+++ b/src/interactiveHandler.py
@@ -51,7 +51,7 @@ class InteractiveHandler:
             transactObj = getHKTransaction(command, networkHandler)
         elif tokens[self.serviceIdx] == "CLI":
             transactObj = satcliTransaction(command, networkHandler)
-        elif tokens[self.serviceIdx] == "SCHEDULER" and (tokens[self.subserviceIdx] in ['SET_SCHEDULE', 'DELETE_SCHEDULE', 'REPLACE_SCHEDULE']):
+        elif tokens[self.serviceIdx] == "SCHEDULER" and (tokens[self.subserviceIdx] == "SET_SCHEDULE"):
             transactObj = schedulerTransaction(command, networkHandler)
         elif tokens[self.serviceIdx] == "TIME_MANAGEMENT" and tokens[self.subserviceIdx] == "SET_TIME":
             transactObj = setTimeTransaction(command, networkHandler)
@@ -74,7 +74,7 @@ class InteractiveHandler:
             self.fake_hk_id += 1
         elif tokens[self.serviceIdx] == "CLI":
             transactObj = dummySatCliTransaction(command, networkHandler)
-        elif tokens[self.serviceIdx] == "SCHEDULER" and (tokens[self.subserviceIdx] in ['SET_SCHEDULE', 'DELETE_SCHEDULE', 'REPLACE_SCHEDULE']):
+        elif tokens[self.serviceIdx] == "SCHEDULER" and (tokens[self.subserviceIdx] in ['SET_SCHEDULE', 'DELETE_SCHEDULE']):
             transactObj = dummySchedulerTransaction(command, networkHandler)
         else:
             transactObj = dummyTransaction(command, networkHandler)

--- a/src/scheduleParser.py
+++ b/src/scheduleParser.py
@@ -37,7 +37,8 @@ class ScheduleParser:
     def __init__(self, cmdList = None):
         self.cmdList = cmdList
         self.cmds = []
-        self.now = []
+        self.now = None
+        self.listnow = []
         self.repeat = 0
 
     def _splitdt(self, dt: datetime):
@@ -72,28 +73,52 @@ class ScheduleParser:
             self.cmds.append(self._parseCmd(cron))
 
     def _parseWildcard(self, index: int, field: str):
-        if not self.now:
-            # lazy initialization
-            self.now = datetime.now(timezone.utc)
-            listnow = self._splitdt(self.now)
-
         if self.repeat != 0:
-            return listnow[index]
+            return self.listnow[index]
 
         # Limitations: we don't support wildcard milliseconds, and if you
         # specify month as a wildcard we assume all months contain 30 days.
         # If this turns out to be a problem we can figure something out.
         periods = [0, 1, 60, 60*60, 24*60*60, 30*24*60*60, 0]
 
+        first = self.listnow[index]
         slash = field.find('/')
         if slash == -1:
             self.repeat = periods[index]
         else:
-            self.repeat = int(field[slash+1:])*periods[index]
-
-        return listnow[index]
+            print("step in index {}: {}".format(index, field))
+            step = int(field[slash+1:])
+            self.repeat = step*periods[index]
+            # To calculate first, move to the next step multiple.
+            # For example, if field=7 and step=5, bump field to 10
+            rem = first % step
+            if rem > 0:
+                maxs = [999, 59, 59, 23, 31, 2023]
+                print("now[{}]={}, step={}, new={}".format(index, first, step,
+                                                           first+step-rem))
+                first = first + (step - rem)
+                if first > maxs[index]:
+                    # The tricky part about bumping a field is that it may
+                    # need to wrap and overflow to the next field. And then
+                    # the next field could overflow, etc. The most obvious
+                    # example is incrementing the seconds field at 23:59:59.
+                    print("overflow {}, at index {}".format(first, index))
+                    self.listnow[index] = first
+                    for i in range(index,6):
+                        if self.listnow[i] > maxs[i]:
+                            print("overflow at {}: {}".format(i, self.listnow[i]))
+                            self.listnow[i] -= maxs[i] + 1
+                            self.listnow[i+1] += 1
+                            if i >= 3:
+                                print("Warning: overflow into day/month {}".format(field))
+                    first = self.listnow[index]
+        return first
 
     def parseCmd(self, cronspec: str):
+        self.now = datetime.now(timezone.utc)
+        self.listnow = self._splitdt(self.now)
+        self.repeat = 0
+
         cmd = {}
         cmdfields = cronspec.split()
         timefields = []
@@ -117,9 +142,22 @@ class ScheduleParser:
                                second=timefields[1],
                                microsecond=timefields[0]*1000,
                                tzinfo=timezone.utc)
+
         cmd['first'] = calendar.timegm(nextdt.timetuple())
+        if nextdt < self.now:
+            # Particularly for periodic commands, it's possible that first has
+            # already passed. For example, for "0 0 */5 * * *" it's possible we
+            # calculated first to be 11:05:00, and it's already 11:07:00. Just
+            # add the period and we should get 11:10:00.
+            print("Warning: cron spec {} < now {}".format(nextdt, self.now))
+            if self.repeat > 0:
+               cmd['first'] += self.repeat
+               print("Adjusting first by {} sec to {}".format(self.repeat,
+                             datetime.fromtimestamp(cmd['first'], timezone.utc)))
+
         cmd['repeat'] = self.repeat
         cmd['last'] = 0
         cmd['op'] = " ".join(cmdfields[7:])
+
         print("cmd: {}".format(cmd))
         return cmd

--- a/src/scheduleParser.py
+++ b/src/scheduleParser.py
@@ -1,0 +1,125 @@
+'''
+ * Copyright (C) 2022  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file scheduleParser.py
+ * @author Ron Unrau
+ * @date 2023-02-01
+'''
+from datetime import datetime
+from datetime import timezone
+import calendar
+
+class ScheduleParser:
+    """A class that contains methods to parse an AlbertaSat schedule.
+
+    An AlbertaSat schedule is based loosely on crontab(5). A schedule comprises
+    multiple commands, where each command is of the form "<cron spec> <task>".
+    A <cron spec> has time fields of the form "msec sec min hr day mo yr", where
+    each time field (except milliseonds) is allowed to contain a wildcard.
+    Wildcards can be '*', which means repeat every unit (sec, min, etc) or 
+    '*/<step>', which means repeat every <step> units. A <cron spec> is parsed
+    into a (first, repeat, last) tuple, which effectively say "run this <task>
+    at time <first>, and every <repeat> seconds until <last>. The three times
+    are given as Unix UTC timestamps.
+    """
+
+    def __init__(self, cmdList = None):
+        self.cmdList = cmdList
+        self.cmds = []
+        self.now = []
+        self.repeat = 0
+
+    def _splitdt(self, dt: datetime):
+        """Split the fields of a datetime object into a list
+
+        The (ordered) list allows us to refer to datetime fields by position vs
+        name. Note that datetime uses microseconds and full years, whereas we
+        use milliseconds and (optionally) abbreviated years.
+        """
+
+        listdt = []
+        listdt.append(dt.microsecond)
+        listdt.append(dt.second)
+        listdt.append(dt.minute)
+        listdt.append(dt.hour)
+        listdt.append(dt.day)
+        listdt.append(dt.month)
+        listdt.append(dt.year)
+        return listdt
+
+    def parseCmdList(self, cmdList = None):
+        """Parse all the commands in the list provided.
+
+        If cmdList is provided, it over-rides the one provided in the constructor
+        """
+
+        if cmdList:
+           self.cmdList = cmdList
+        for cron in self.cmdList:
+            print("cmd: <{}>".format(cron))
+            self.repeat = 0
+            self.cmds.append(self._parseCmd(cron))
+
+    def _parseWildcard(self, index: int, field: str):
+        if not self.now:
+            # lazy initialization
+            self.now = datetime.now(timezone.utc)
+            listnow = self._splitdt(self.now)
+
+        if self.repeat != 0:
+            return listnow[index]
+
+        # Limitations: we don't support wildcard milliseconds, and if you
+        # specify month as a wildcard we assume all months contain 30 days.
+        # If this turns out to be a problem we can figure something out.
+        periods = [0, 1, 60, 60*60, 24*60*60, 30*24*60*60, 0]
+
+        slash = field.find('/')
+        if slash == -1:
+            self.repeat = periods[index]
+        else:
+            self.repeat = int(field[slash+1:])*periods[index]
+
+        return listnow[index]
+
+    def parseCmd(self, cronspec: str):
+        cmd = {}
+        cmdfields = cronspec.split()
+        timefields = []
+        for i in range(7):
+            if cmdfields[i].isnumeric():
+                timefields.append(int(cmdfields[i]))
+            elif cmdfields[i].find('*') != -1:
+                timefields.append(self._parseWildcard(i, cmdfields[i]))
+            else:
+                print("illegal cron specifier: {}".format(cmdfields[i]))
+                timefields.append(0)
+
+        if timefields[6] < 2000:  # support years as 2023 or 23
+            timefields[6] += 2000
+
+        # Create a datetime object to hold the first/next scheduled time
+        # Note the constructor throws a value exception if any of the fields are
+        # out of legal range (including 0 for day, month, and year)
+        nextdt = datetime(timefields[6], timefields[5], timefields[4],
+                               hour=timefields[3], minute=timefields[2],
+                               second=timefields[1],
+                               microsecond=timefields[0]*1000,
+                               tzinfo=timezone.utc)
+        cmd['first'] = calendar.timegm(nextdt.timetuple())
+        cmd['repeat'] = self.repeat
+        cmd['last'] = 0
+        cmd['op'] = " ".join(cmdfields[7:])
+        print("cmd: {}".format(cmd))
+        return cmd

--- a/src/system.py
+++ b/src/system.py
@@ -540,49 +540,30 @@ services = {
                     'args': None,  # All scheduled commands should be stored in schedule.txt
                     'returns': {
                         'err': '>b',
-                        'number of cmds scheduled': '>b'  # Returns -1 if an error occurred.
-                    }
-                }
-            },
-            'GET_SCHEDULE': {
-                'subPort': 1,
-                'inoutInfo': {
-                    'args': None,
-                    'returns': {
-                        'err': '>b'  # Refer to rederrno.h for reliance edge error codes
-                    }
-                }
-            },
-            'REPLACE_SCHEDULE': {
-                'what': 'Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes',
-                'subPort': 2,
-                'inoutInfo': {
-                    'args': None,
-                    'returns': {
-                        'err': '>b',
-                        'number of cmds scheduled': '>b'    # Returns -1 if an error occurred.
+                        'count': '>b'  # Returns -1 if an error occurred.
                     }
                 }
             },
             'DELETE_SCHEDULE': {
-                'what': 'Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes',
+                'what': 'Returns 0 on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes',
                 'subPort': 3,
                 'inoutInfo': {
                     'args': None,
                     'returns': {
-                        'err': '>b', \
-                        'number of cmds scheduled': '>b'    # Returns -1 if an error occurred.
+                        'err': '>b',
+                        'red_errno': '>b'  # RED errno if I/O error occurred
                     }
                 }
             },
-            'PING_SCHEDULE': {
+            'GET_SCHEDULE': {
                 'what': 'Returns 0 and number of cmds left in the schedule on success. Refer for schedule.h for calloc error code. Refer to rederrno.h for reliance edge error codes',
-                'subPort': 4,
+                'subPort': 1,
                 'inoutInfo': {
                     'args': None,
                     'returns': {
                         'err': '>b',
-                        'number of cmds scheduled': '>b'    # Returns -1 if an error occurred.
+                        'count': '>b',
+                        'cmds': 'var'
                     }
                 }
             },
@@ -4855,7 +4836,8 @@ services = {
                 'subPort': 11,
                 'inoutInfo': {
                     'args': {
-                        "Repeats": '>u2',
+                        "CSP": '>b',
+                        "Repeats": '>u1',
                         "Blocksize": '>u2',
                         "Filename" : '>S128'
                     },


### PR DESCRIPTION
This is the ground station side of the new scheduler. You will notice that all the cron parsing is done on the ground so that a completely binary packet is sent in SET_SCHEDULE. This makes the satellites job a lot easier, and hopefully more reliable. We can also change the format of the cron spec easily, because the satellite never sees it. I also removed REPLACE_SCHEDULE and changed DELETE_SCHEDULE to always delete the entire schedule. Finally, GET_SCHEDULE now returns the actual scheduled times and target (via <dst,dport>) of all the scheduled commands.

Although this version of the ground station scheduler is incompatible with the current satellite scheduler, we can't practically use the satellite scheduler anyway, so it should hurt to merge this PR.