### PR TITLE
Upgraded python to 3.9

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.10'
+          python-version: '3.9'
           architecture: 'x64'
       - name: Install numpy
         run: python3 -m pip install numpy


### PR DESCRIPTION
It's now exactly the same version of python used in ex2_ground_station_website. Apparently Github upgraded to Ubuntu 22.04 which has different python versions available.