### PR TITLE
ftp partial upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test_dfgm": "LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_dfgm.py",
     "test_iris": "LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_iris.py",
     "test_audio": "LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build python3 test/test_audio.py",
+    "pytest": "LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build:.:./src pytest",
     "beacon_decoder": "python3 src/beaconDecoder.py"
   }
 }

--- a/src/ftp.py
+++ b/src/ftp.py
@@ -266,7 +266,16 @@ class ftpSender(ftp):
         with open(self.infile, "rb") as f:
             filesize = os.path.getsize(self.infile)
             req_id = randint(0, 1653514975);
-            print("Sending file {} to satellite".format(self.infile))
+            count = 0
+            if self.skip != 0:
+                # Note: // is the floor, or integer divide operator
+                skip_blks = self.skip // self.blocksize
+                count = skip_blks
+                self.skip = skip_blks * self.blocksize
+                f.seek(self.skip)  # skip is in bytes
+
+            print("Sending file {} size {} offset {} to satellite"
+                  .format(self.infile, filesize, self.skip))
             packet = self._get_start_upload_packet(req_id, filesize);
             data = self._transaction(packet)
             if (data is None):
@@ -275,7 +284,6 @@ class ftpSender(ftp):
             if data['err'] < 0:
                 print("error {} from upload start packet".format(data['err']))
             done = False
-            count = 0
             while not done:
                 print("Sending packet {}/{}".format(count, int(filesize/self.blocksize)))
                 data = f.read(self.blocksize)

--- a/src/ftp.py
+++ b/src/ftp.py
@@ -111,6 +111,7 @@ class ftp(GroundStation):
         self.operation = ''
         self.infile = opts.get if opts.get != '' else opts.post
         self.outfile = ''
+        self.skip = opts.skip
 
         if opts.outfile:
             self.outfile = opts.outfile
@@ -183,7 +184,7 @@ class ftpGetter(ftp):
         print("Requesting file {} from satellite".format(self.infile))
         self._do_get_request()
 
-    def shutdown(self, arg1, arg2):
+    def shutdown(self):
         if not os.path.exists(".ftpTransactions"):
             os.mkdir(".ftpTransactions")
         with open(".ftpTransactions/{}.pickle".format(self.currentTransaction.getReqID()), "wb") as dumpfile:
@@ -255,9 +256,8 @@ class ftpGetter(ftp):
         return out
 
 class ftpSender(ftp):
-    def __init__(self,opts):
+    def __init__(self, opts):
         super().__init__(opts)
-        self.skip = 0
 
     def run(self):
         self._do_post_request()

--- a/src/options.py
+++ b/src/options.py
@@ -36,7 +36,7 @@ class Options(object):
     def __init__(self):
         self.parser = argparse.ArgumentParser(description='Parses command.')
 
-    def getOptions(self):
+    def getOptions(self, argv=None):
         self.parser.add_argument(
             '--hkeyfile',
             type=str,
@@ -85,7 +85,11 @@ class Options(object):
             default=True,
             help="Use forward error correction"
         )
-        return self.parser.parse_args(sys.argv[1:])
+        if argv:
+            opts = self.parser.parse_args(argv)
+        else:
+            opts = self.parser.parse_args(sys.argv[1:])
+        return opts
 
 class UpdateOptions(Options):
     def __init__(self):
@@ -130,7 +134,7 @@ class FTPOptions(Options):
     def __init__(self):
         super().__init__();
 
-    def getOptions(self):
+    def getOptions(self, argv=None):
         self.parser.add_argument(
             '-g',
             '--get',
@@ -167,7 +171,13 @@ class FTPOptions(Options):
             default=0,
             help="Attempt to resume download with given ID"
         )
-        return super().getOptions();
+        self.parser.add_argument(
+            '--skip',
+            type=int,
+            default=0,
+            help="Number of bytes to skip"
+        )
+        return super().getOptions(argv);
 
 class SBANDOptions(Options):
     def __init__(self):

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -12,12 +12,14 @@
  * GNU General Public License for more details.
 '''
 '''
- * @file test_scheduler.py
+ * @file test_ftp.py
  * @author Ron Unrau
  * @date
 '''
 
-'''  to run > yarn test_scheduler -I uart '''
+'''  to run > LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build:./:./src:./test python3 test/test_ftp.py -I sdr -d /dev/ttyUSB0 '''
+
+import subprocess
 
 from datetime import datetime
 from datetime import timezone
@@ -27,6 +29,7 @@ import calendar
 from src.options import optionsFactory
 from src.options import Options
 from src.ftp import ftpSender
+from src.ftp import ftpGetter
 
 from testLib import testLib as test
 from testLib import gs
@@ -74,9 +77,26 @@ def test_ftp_upload():
     options = "-p README.md -d /dev/ttyUSB0".split()
     ftpRunner = ftpSender(opts.getOptions(argv=options))
     ftpRunner.run()
-    
-    print("done")
+
+def test_ftp_partial_upload():
+    opts = optionsFactory("ftp")
+    options = "-p README.md --skip 1024 -d /dev/ttyUSB0".split()
+    ftpRunner = ftpSender(opts.getOptions(argv=options))
+    ftpRunner.run()
+
+def test_ftp_download():
+    cmdout = subprocess.check_output(["rm", "-f", "readme.tst"])
+
+    opts = optionsFactory("ftp")
+    options = "-g README.md -o readme.tst -d /dev/ttyUSB0".split()
+    ftpRunner = ftpGetter(opts.getOptions(argv=options))
+    ftpRunner.run()
+
+    cmdout = subprocess.check_output(["diff", "README.md", "readme.tst"])
+    print("diff: {}".format(cmdout))
 
 if __name__ == '__main__':
     test_time()
     test_ftp_upload()
+    test_ftp_partial_upload()
+    test_ftp_download()

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -31,47 +31,6 @@ from src.options import Options
 from src.ftp import ftpSender
 from src.ftp import ftpGetter
 
-from testLib import testLib as test
-from testLib import gs
-
-test = test() #call to initialize local test class
-
-def test_scheduler_get():
-    test.send('ex2.scheduler.get_schedule')
-
-def test_time():
-    # Get the current satellite time and adjust it if necessary. By updating
-    # the satellite's time subsequent tests can safely use "now" to manage
-    # schedules and check results.
-    cmd = "ex2.time_management.get_time"
-    transactObj = gs.interactive.getTransactionObject(cmd, gs.networkManager)
-
-    # get the current time as UTC
-    dt = datetime.now(timezone.utc)
-    now = calendar.timegm(dt.timetuple())
-
-    response = transactObj.execute()
-    if response == {} or response['err'] != 0:
-        print("get_time error: {}".format(response))
-        return
-
-    print("now: {}, sat: {}".format(now, response))
-    sat = int(response['timestamp'])
-    dt = datetime.fromtimestamp(sat)
-    # Arbitrarily decide that a 10 second diference is "close enough"
-    if abs(sat - now) < 10:
-        print("satellite time {} (delta {})".format(dt, sat - now))
-        return
-
-    print("adjusting satellite time {} (delta {})".format(dt, sat - now))
-
-    cmd = "ex2.time_management.set_time({})".format(now)
-    transactObj = gs.interactive.getTransactionObject(cmd, gs.networkManager)
-    # set the satellite's time to this script's time
-    response = transactObj.execute()
-    assert response != {}, "set_schedule - no response"
-    assert response['err'] == 0
-    
 def test_ftp_upload():
     opts = optionsFactory("ftp")
     options = "-p README.md -d /dev/ttyUSB0".split()
@@ -96,7 +55,6 @@ def test_ftp_download():
     print("diff: {}".format(cmdout))
 
 if __name__ == '__main__':
-    test_time()
     test_ftp_upload()
     test_ftp_partial_upload()
     test_ftp_download()

--- a/test/test_ftp.py
+++ b/test/test_ftp.py
@@ -1,0 +1,82 @@
+'''
+ * Copyright (C) 2023  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+'''
+'''
+ * @file test_scheduler.py
+ * @author Ron Unrau
+ * @date
+'''
+
+'''  to run > yarn test_scheduler -I uart '''
+
+from datetime import datetime
+from datetime import timezone
+from datetime import timedelta
+import calendar
+
+from src.options import optionsFactory
+from src.options import Options
+from src.ftp import ftpSender
+
+from testLib import testLib as test
+from testLib import gs
+
+test = test() #call to initialize local test class
+
+def test_scheduler_get():
+    test.send('ex2.scheduler.get_schedule')
+
+def test_time():
+    # Get the current satellite time and adjust it if necessary. By updating
+    # the satellite's time subsequent tests can safely use "now" to manage
+    # schedules and check results.
+    cmd = "ex2.time_management.get_time"
+    transactObj = gs.interactive.getTransactionObject(cmd, gs.networkManager)
+
+    # get the current time as UTC
+    dt = datetime.now(timezone.utc)
+    now = calendar.timegm(dt.timetuple())
+
+    response = transactObj.execute()
+    if response == {} or response['err'] != 0:
+        print("get_time error: {}".format(response))
+        return
+
+    print("now: {}, sat: {}".format(now, response))
+    sat = int(response['timestamp'])
+    dt = datetime.fromtimestamp(sat)
+    # Arbitrarily decide that a 10 second diference is "close enough"
+    if abs(sat - now) < 10:
+        print("satellite time {} (delta {})".format(dt, sat - now))
+        return
+
+    print("adjusting satellite time {} (delta {})".format(dt, sat - now))
+
+    cmd = "ex2.time_management.set_time({})".format(now)
+    transactObj = gs.interactive.getTransactionObject(cmd, gs.networkManager)
+    # set the satellite's time to this script's time
+    response = transactObj.execute()
+    assert response != {}, "set_schedule - no response"
+    assert response['err'] == 0
+    
+def test_ftp_upload():
+    opts = optionsFactory("ftp")
+    options = "-p README.md -d /dev/ttyUSB0".split()
+    ftpRunner = ftpSender(opts.getOptions(argv=options))
+    ftpRunner.run()
+    
+    print("done")
+
+if __name__ == '__main__':
+    test_time()
+    test_ftp_upload()

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -17,17 +17,14 @@
  * @date
 '''
 
-'''  to run > yarn test_scheduler -I uart '''
+'''  to run > LD_LIBRARY_PATH=./libcsp/build PYTHONPATH=./libcsp/build:./:./src:./test python3 test/test_scheduler.py -I sdr -d /dev/ttyUSB0 '''
 
 import numpy as np
 import os
 
-import sys
-from os import path
-sys.path.append("./test")
-
-from testLib import testLib as test
-from testLib import gs
+from src.groundStation import GroundStation
+from src.options import optionsFactory
+from src.options import Options
 
 import time
 from datetime import datetime
@@ -35,7 +32,8 @@ from datetime import timezone
 from datetime import timedelta
 import calendar
 
-test = test() #call to initialize local test class
+opts = optionsFactory("basic")
+gs = GroundStation(opts.getOptions(argv="-I sdr".split()))
 
 class CronTime:
     def __init__(self, dt : datetime):
@@ -74,9 +72,6 @@ class CronTime:
         for key in self.cron:
             fmt += "{} ".format(self.cron[key])
         return fmt                
-
-def test_scheduler_get():
-    test.send('ex2.scheduler.get_schedule')
 
 def test_time():
     # Get the current satellite time and adjust it if necessary. By updating


### PR DESCRIPTION
Add the --skip parameter for upload (post), which is specified in bytes but truncated to blocks. Use the skip parameter to send partial files to the satellite. I also included some simple tests to exercise the functionality
