### PR TITLE
Deployable current consumption was removed as a parameter return

### DIFF
--- a/CommandDocs.txt
+++ b/CommandDocs.txt
@@ -166,7 +166,7 @@ GENERAL.DEPLOY_DEPLOYABLES:
 		About: Trigger burnwire. DFGM=0, UHF_P=1, UHF_Z=2, UHF_S=3, UHF_N=4. Solar panels: Port=5, Payload=6, Starboard=7. Returns instantaneous current consumption
 		Supports: OBC
 		Arguments: {'Wire': '>B'}
-		return values: {'err': '>b', 'current_mA': '>u2'}
+		return values: {'err': '>b'}
 		port: 11		subport: 1
 
 

--- a/src/system.py
+++ b/src/system.py
@@ -822,8 +822,7 @@ services = {
                         "Wire" : '>B'
                     },
                     'returns': {
-                        'err': '>b',  # switch status
-                        'current_mA': '>u2' # current consumed during burning
+                        'err': '>b',  # switch status 
                     }
                 }
             },


### PR DESCRIPTION
Somehow this was missed on the ground station. This parameter does not exist on the OBC side anymore.